### PR TITLE
added dedicated download page

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -1,5 +1,5 @@
 - title: Download
-  link: https://github.com/MRtrix3/mrtrix3/wiki#supported-platforms--installation
+  link: /download/ 
 
 - title: Blog
   link: /blog/

--- a/download.html
+++ b/download.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+
+<div class="home">
+
+    {% assign sorted_pubs = site.data.publications | sort: "year" | reverse %}
+
+    <h1>Download mrtrix</h1>
+
+    <hr>
+
+    <p> <span style="line-height: 25.6px;">For installation instructions, please refer to the corresponding platform&#39;s instructions:</span></p>
+    <ul style="box-sizing: border-box; padding: 0px 0px 0px 2em; margin-top: 0px; margin-bottom: 16px; color: rgb(51, 51, 51);">
+        <li style="box-sizing: border-box;">
+            <a href="https://github.com/MRtrix3/mrtrix3/wiki/Installing%20on%20Linux" style="box-sizing: border-box; color: rgb(64, 120, 192); text-decoration: none; background-color: transparent;">GNU/Linux</a></li>
+        <li style="box-sizing: border-box;">
+            <a href="https://github.com/MRtrix3/mrtrix3/wiki/Installing%20on%20Windows" style="box-sizing: border-box; color: rgb(64, 120, 192); text-decoration: none; background-color: transparent;">MS Windows</a></li>
+        <li style="box-sizing: border-box;">
+            <a href="https://github.com/MRtrix3/mrtrix3/wiki/Installing%20on%20MacOSX" style="box-sizing: border-box; color: rgb(64, 120, 192); text-decoration: none; background-color: transparent;">MacOS X</a></li>
+    </ul>
+
+</div>


### PR DESCRIPTION
Links to the platform specific instructions to avoid visitor confrontation with the rather busy wiki page when all they want is know how to get mrtrix. Untested as I don't know how to render it without merge. Feel free to discard if deemed unnecessary.
