### PR TITLE
moved video to documentation page, added link via button to front page

### DIFF
--- a/_data/frontpage/banner.yml
+++ b/_data/frontpage/banner.yml
@@ -4,3 +4,7 @@ buttons:
     - title: Download
       icon: fa fa-download
       link: /download
+
+    - title: Use MRtrix3
+      icon: fa fa-users
+      link: /documentation

--- a/_data/frontpage/banner.yml
+++ b/_data/frontpage/banner.yml
@@ -6,5 +6,5 @@ buttons:
       link: /download
 
     - title: Use MRtrix3
-      icon: fa fa-users
+      icon: fa fa-cogs
       link: /documentation

--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -1,14 +1,8 @@
-- title: Workshop
-  link: /workshop
-  
 - title: Download
-  link: /download/ 
+  link: /download/
 
 - title: Blog
   link: /blog/
-
-- title: Videos
-  link: /videos
 
 - title: Documentation
   link: /documentation

--- a/documentation.md
+++ b/documentation.md
@@ -6,7 +6,7 @@ layout: default
 
 There are several sources of information to help you get the most out of *MRtrix3*:
 
-- [The official *MRtrix3* reference documentation](https://mrtrix.readthedocs.io/en/latest/). Note that you can access the documentation for specific versions of *MRtrix3* using the green button at the bottom of the sidebar (by default, this will be set to `v:latest`). 
+- [The official *MRtrix3* reference documentation](https://mrtrix.readthedocs.io/en/latest/). Note that you can access the documentation for specific versions of *MRtrix3* using the green button at the bottom of the sidebar (by default, this will be set to `v:latest`).
 
 - The [*MRtrix3* wiki](https://community.mrtrix.org/c/wiki/12), hosted as a category on the [community forum](https://community.mrtrix.org/categories). This contains user-contributed information covering topics that might not fit well within the reference documentation. Users are encouraged to contribute to the wiki if they come across solutions to thorny or interesting problems, etc.
 
@@ -17,7 +17,9 @@ There are several sources of information to help you get the most out of *MRtrix
 - The [B.A.T.M.A.N. tutorial](https://osf.io/fkyht/), authored by [Marlene Tahedl](https://community.mrtrix.org/u/martahedl/summary), provides an excellent overview of a full analysis pipeline using *MRtrix3*, with plenty of examples, helpful strategies and advice about common pitfalls.
 
 - [Andy's Brain Blog](https://www.andysbrainblog.com/), written by [Andrew Jahn](https://www.andysbrainblog.com/about), contains a wealth of information on various topics, including:
-  - a [course on *MRtrix3*](https://andysbrainbook.readthedocs.io/en/latest/MRtrix/MRtrix_Introduction.html) 
-  - a [video series on Youtube](https://www.youtube.com/playlist?list=PLIQIswOrUH68Zi9SVDAdcUExpq2i6A2eD). 
-  
+  - a [course on *MRtrix3*](https://andysbrainbook.readthedocs.io/en/latest/MRtrix/MRtrix_Introduction.html)
+  - a [video series on Youtube](https://www.youtube.com/playlist?list=PLIQIswOrUH68Zi9SVDAdcUExpq2i6A2eD).
+
+- We have collected some videos in our [youtube channel](/videos) that showcase key functionalities of *mrview*.
+
 

--- a/documentation.md
+++ b/documentation.md
@@ -20,6 +20,6 @@ There are several sources of information to help you get the most out of *MRtrix
   - a [course on *MRtrix3*](https://andysbrainbook.readthedocs.io/en/latest/MRtrix/MRtrix_Introduction.html)
   - a [video series on Youtube](https://www.youtube.com/playlist?list=PLIQIswOrUH68Zi9SVDAdcUExpq2i6A2eD).
 
-- We have collected some videos in our [youtube channel](/videos) that showcase key functionalities of *mrview*.
+- The [*MRtrix3* youtube channel](/videos), which showcases key functionalities of *mrview*.
 
 


### PR DESCRIPTION
As discussed, tidied up the menu and made a prominent button on the homepage to the documentation page. Untested as I don't know how to test locally.