### PR TITLE
installation: mention containers and modules, moved compile to end

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -6,13 +6,7 @@ title: Download MRtrix3
 Pre-compiled versions of *MRtrix3* are available for download for all major
 operating systems, and these are the quickest and simplest way of getting
 started with *MRtrix3*. You'll find specific instructions on how to install
-them below. 
-
-If you need to compile and install *MRtrix3* from source, you'll find
-instructions for all major operating systems on our [documentation
-site](https://mrtrix.readthedocs.io/en/latest/installation/build_from_source.html).
-The process is also generally relatively simple, but it does require more
-computing resources and expertise.
+them below.
 
 GNU/Linux
 =========
@@ -30,3 +24,24 @@ Microsoft Windows
 =================
 
 - [through MSYS2]({{ site.baseurl }}/download/windows-msys2)
+
+
+Containers
+==========
+
+We now also provide Docker and Singularity [containers](https://mrtrix.readthedocs.io/en/latest/installation/using_containers.html).
+
+
+Compile from source
+===================
+
+If you need to compile and install *MRtrix3* from source, you'll find
+instructions for all major operating systems on our [documentation
+site](https://mrtrix.readthedocs.io/en/latest/installation/build_from_source.html).
+The process is also generally relatively simple, but it does require more
+computing resources and expertise. 
+
+If you are developing your own module or command line tools using the 
+*MRtrix3* core library, please see the [external modules](https://mrtrix.readthedocs.io/en/latest/tips_and_tricks/external_modules.html)
+documenation site.
+


### PR DESCRIPTION
Tweaks to the installation instructions: 
The order of the text seemed slightly off. It mentioned the precompiled packages followed by how to compile from source and then listing the precompiled packages. Now also mentioning containers and while at it hinting at modules.